### PR TITLE
Remover PyCon Latam

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@
 
 |Eventos ainda sem data|
 |----------------------|
-|Pycon LATAM|
+||
 
 
 ###   setembro 2019


### PR DESCRIPTION
Opa! 

Removendo a PyCon LATAM, já que não é um evento brasileiro e, sim, Mexicano.